### PR TITLE
add cmd_vel_topic param

### DIFF
--- a/husarion_ugv_crsf_teleop/config/crsf_teleop_lynx.yaml
+++ b/husarion_ugv_crsf_teleop/config/crsf_teleop_lynx.yaml
@@ -4,7 +4,8 @@
       port: /dev/ttyUSBPAD
       baud: 576000
       cmd_vel_stamped: true
+      cmd_vel_topic: manual/cmd_vel
       e_stop_republish: false
-      enable_cmd_vel_silence_switch: false
+      enable_cmd_vel_silence_switch: true
       linear_speed_presets: [0.5, 0.9, 1.5]
       angular_speed_presets: [0.45, 0.9, 2.0]

--- a/husarion_ugv_crsf_teleop/config/crsf_teleop_lynx.yaml
+++ b/husarion_ugv_crsf_teleop/config/crsf_teleop_lynx.yaml
@@ -4,7 +4,7 @@
       port: /dev/ttyUSBPAD
       baud: 576000
       cmd_vel_stamped: true
-      cmd_vel_topic: manual/cmd_vel
+      cmd_vel_topic: cmd_vel
       e_stop_republish: false
       enable_cmd_vel_silence_switch: true
       linear_speed_presets: [0.5, 0.9, 1.5]

--- a/husarion_ugv_crsf_teleop/config/crsf_teleop_panther.yaml
+++ b/husarion_ugv_crsf_teleop/config/crsf_teleop_panther.yaml
@@ -4,7 +4,7 @@
       port: /dev/ttyUSBPAD
       baud: 576000
       cmd_vel_stamped: true
-      cmd_vel_topic: manual/cmd_vel
+      cmd_vel_topic: cmd_vel
       e_stop_republish: false
       enable_cmd_vel_silence_switch: true
       linear_speed_presets: [0.4, 1.2, 2.0]

--- a/husarion_ugv_crsf_teleop/config/crsf_teleop_panther.yaml
+++ b/husarion_ugv_crsf_teleop/config/crsf_teleop_panther.yaml
@@ -4,7 +4,8 @@
       port: /dev/ttyUSBPAD
       baud: 576000
       cmd_vel_stamped: true
+      cmd_vel_topic: manual/cmd_vel
       e_stop_republish: false
-      enable_cmd_vel_silence_switch: false
+      enable_cmd_vel_silence_switch: true
       linear_speed_presets: [0.4, 1.2, 2.0]
       angular_speed_presets: [0.39, 0.78, 1.88]

--- a/husarion_ugv_crsf_teleop/husarion_ugv_crsf_teleop/crsf_teleop_node.py
+++ b/husarion_ugv_crsf_teleop/husarion_ugv_crsf_teleop/crsf_teleop_node.py
@@ -60,6 +60,7 @@ class CRSFInterface(Node):
             port,
             baud,
             self._cmd_vel_stamped,
+            cmd_vel_topic,
             e_stop_republish,
             self._enable_cmd_vel_silence_switch,
             self._linear_speed_presets,
@@ -69,6 +70,7 @@ class CRSFInterface(Node):
                 "port",
                 "baud",
                 "cmd_vel_stamped",
+                "cmd_vel_topic",
                 "e_stop_republish",
                 "enable_cmd_vel_silence_switch",
                 "linear_speed_presets",
@@ -78,7 +80,7 @@ class CRSFInterface(Node):
 
         self._cmd_vel_publisher = self.create_publisher(
             TwistStamped if self._cmd_vel_stamped.value else Twist,
-            "cmd_vel",
+            cmd_vel_topic.value,
             QoSProfile(
                 reliability=QoSReliabilityPolicy.RELIABLE,
                 durability=QoSDurabilityPolicy.VOLATILE,
@@ -142,6 +144,11 @@ class CRSFInterface(Node):
             "cmd_vel_stamped",
             False,
             ParameterDescriptor(description="Publish cmd_vel as TwistStamped instead of Twist"),
+        )
+        self.declare_parameter(
+            "cmd_vel_topic",
+            "cmd_vel",
+            ParameterDescriptor(description="Topic to publish cmd_vel messages to"),
         )
         self.declare_parameter(
             "e_stop_republish",


### PR DESCRIPTION
Add `cmd_vel_topic` param, this is done to ease future integration when new driver with `manual/cmd_vel` is introduced
Also, changes `enable_cmd_vel_silence_switch` default value to `true`, as in most cases this configuration is used