### PR TITLE
Fixed statcking parser after wrong crc

### DIFF
--- a/husarion_ugv_crsf_teleop/husarion_ugv_crsf_teleop/crsf/parser.py
+++ b/husarion_ugv_crsf_teleop/husarion_ugv_crsf_teleop/crsf/parser.py
@@ -100,7 +100,7 @@ class CRSFParser:
             self.state = self.State.MSG_TYPE
             return IN_PROGRESS
 
-        elif self.state == self.state.MSG_TYPE:
+        elif self.state == self.State.MSG_TYPE:
             try:
                 self._msg.msg_type = PacketType(byte)
             except ValueError:
@@ -131,10 +131,10 @@ class CRSFParser:
             return IN_PROGRESS
 
         elif self.state == self.State.MSG_CRC:
-            if self._msg.calculate_crc() == byte:
-                # Reset parser
-                self.state = self.State.SEEK_SYNC
+            # Reset parser
+            self.state = self.State.SEEK_SYNC
 
+            if self._msg.calculate_crc() == byte:
                 # Packet len consists of payload length + 4 bytes for sync, len, type and crc
                 # + 2 bytes if packet has an extended format
                 return (

--- a/husarion_ugv_crsf_teleop/husarion_ugv_crsf_teleop/crsf_teleop_node.py
+++ b/husarion_ugv_crsf_teleop/husarion_ugv_crsf_teleop/crsf_teleop_node.py
@@ -251,14 +251,7 @@ class CRSFInterface(Node):
                 self.get_logger().error("Connection lost")
 
                 # Publish empty cmd_vel to stop the robot
-                empty_twist = Twist()
-                if self._cmd_vel_stamped.value:
-                    twist_stamped_msg = TwistStamped()
-                    twist_stamped_msg.header.stamp = self.get_clock().now().to_msg()
-                    twist_stamped_msg.twist = empty_twist
-                    self._cmd_vel_publisher.publish(twist_stamped_msg)
-                else:
-                    self._cmd_vel_publisher.publish(empty_twist)
+                self._publish_twist(Twist())
 
             if last_lq == 0 and self._link_status.lq > 0:
                 self.get_logger().info("Connected")


### PR DESCRIPTION
Parser stacks when CRC is wrong. The change makes that the state of the parser during calculating CRC is always changed to finding SYNC byte. 

Firstly do https://github.com/husarion/husarion_ugv_crsf_teleop/pull/12